### PR TITLE
Asset Host Support

### DIFF
--- a/lib/javascript_tags.rb
+++ b/lib/javascript_tags.rb
@@ -41,13 +41,13 @@ The above example will produce the following:
       path = javascript.path
       optional_attributes = tag.attr.except('slug', 'name', 'as', 'type').inject('') { |s, (k, v)| s << %{#{k}="#{v}" } }.strip
       optional_attributes = " #{optional_attributes}" unless optional_attributes.empty?
+      asset_host = (Radiant::Config['sheets.asset_host'] ? Radiant::Config['sheets.asset_host'] : '')
       case tag.attr['as']
       when 'url','path'
-        path
+        asset_host+path
       when 'inline'
         %{<script type="#{mime_type}"#{optional_attributes}>\n//<![CDATA[\n#{javascript.render_part('body')}\n//]]>\n</script>}
       when 'link'
-        asset_host = (Radiant::Config['sheets.asset_host'] ? Radiant::Config['sheets.asset_host'] : '')
         %{<script type="#{mime_type}" src="#{asset_host}#{path}"#{optional_attributes}></script>}
       else
         javascript.render_part('body')

--- a/lib/javascript_tags.rb
+++ b/lib/javascript_tags.rb
@@ -47,7 +47,8 @@ The above example will produce the following:
       when 'inline'
         %{<script type="#{mime_type}"#{optional_attributes}>\n//<![CDATA[\n#{javascript.render_part('body')}\n//]]>\n</script>}
       when 'link'
-        %{<script type="#{mime_type}" src="#{path}"#{optional_attributes}></script>}
+        asset_host = (Radiant::Config['sheets.asset_host'] ? Radiant::Config['sheets.asset_host'] : '')
+        %{<script type="#{mime_type}" src="#{asset_host}#{path}"#{optional_attributes}></script>}
       else
         javascript.render_part('body')
       end

--- a/lib/stylesheet_tags.rb
+++ b/lib/stylesheet_tags.rb
@@ -50,7 +50,8 @@ The above example will produce the following:
       when 'inline'
         %{<style type="#{mime_type}"#{optional_attributes}>\n/*<![CDATA[*/\n#{stylesheet.render_part('body')}\n/*]]>*/\n</style>}
       when 'link'
-        %{<link rel="#{rel}" type="#{mime_type}" href="#{path}"#{optional_attributes} />}
+        asset_host = (Radiant::Config['sheets.asset_host'] ? Radiant::Config['sheets.asset_host'] : '')
+        %{<link rel="#{rel}" type="#{mime_type}" href="#{asset_host}#{path}"#{optional_attributes} />}
       else
         stylesheet.render_part('body')
       end

--- a/lib/stylesheet_tags.rb
+++ b/lib/stylesheet_tags.rb
@@ -44,13 +44,13 @@ The above example will produce the following:
       rel = tag.attr.delete('rel') || 'stylesheet'
       optional_attributes = tag.attr.except('slug', 'name', 'as', 'type').inject('') { |s, (k, v)| s << %{#{k}="#{v}" } }.strip
       optional_attributes = " #{optional_attributes}" unless optional_attributes.empty?
+      asset_host = (Radiant::Config['sheets.asset_host'] ? Radiant::Config['sheets.asset_host'] : '')
       case tag.attr['as']
       when 'url','path'
-        path
+        asset_host+path
       when 'inline'
         %{<style type="#{mime_type}"#{optional_attributes}>\n/*<![CDATA[*/\n#{stylesheet.render_part('body')}\n/*]]>*/\n</style>}
       when 'link'
-        asset_host = (Radiant::Config['sheets.asset_host'] ? Radiant::Config['sheets.asset_host'] : '')
         %{<link rel="#{rel}" type="#{mime_type}" href="#{asset_host}#{path}"#{optional_attributes} />}
       else
         stylesheet.render_part('body')

--- a/spec/ci/before_script
+++ b/spec/ci/before_script
@@ -1,14 +1,42 @@
+#!/usr/bin/env bash
+
+# all 'test's before 'ue' or will exit when test fails
+
+test "$WITH_RVM" || WITH_RVM="true"
+test "$RADIANT_VERSION" || RADIANT_VERSION="master"
+test "$DB" || DB="sqlite"
+test -e ~/radiant && rm -rf ~/radiant
+
+
+set -xue
+
+start_path="$( pwd )"
+
 cd ~
 git clone git://github.com/radiant/radiant.git
 cd ~/radiant
+
 if [[ $RADIANT_VERSION != "master" ]]
 then
   git checkout -b $RADIANT_VERSION $RADIANT_VERSION
 fi
-cp -r ~/builds/*/radiant-sheets-extension vendor/extensions/sheets
-gem install bundler --pre
+
+cp -r $start_path vendor/extensions/sheets
+gem install bundler --no-ri --no-rdoc
+
 echo 'gem "radiant-sheets-extension", :path => "vendor/extensions/sheets"' >> Gemfile
-bundle install
+echo 'gemspec' >> Gemfile
+
+# I really dislike using rvm gemset, but while testing this 
+# script I got sick having to install the same gems over and
+# over again.
+if [[ $WITH_RVM == "true" ]]; then
+        rvm gemset create radiant_development
+        rvm gemset use radiant_development
+        bundle install
+else
+        bundle install --path ./vendor/bundle
+fi
 
 case $DB in
   "mysql" )
@@ -17,7 +45,9 @@ case $DB in
   "postgres" )
     psql -c 'create database radiant_test;' -U postgres
     cp spec/ci/database.postgresql.yml config/database.yml;;
+  "sqlite" )
+    cp spec/ci/database.sqlite.yml config/database.yml;;
 esac
 
-bundle exec rake db:migrate
-bundle exec rake db:migrate:extensions
+RAILS_ENV=test bundle exec rake db:migrate --trace 
+RAILS_ENV=test bundle exec rake db:migrate:extensions --trace

--- a/spec/ci/script
+++ b/spec/ci/script
@@ -1,2 +1,25 @@
+#!/usr/bin/env bash
+
+# all 'test's before 'ue' or will exit when test fails
+test "$WITH_RVM" || WITH_RVM="true"
+
+set -xue
+
+start_path="$( pwd )"
+
+# I really dislike using rvm gemset, but while testing this 
+# script I got sick having to install the same gems over and
+# over again.
+if [[ $WITH_RVM == "true" ]]; then
+        rvm gemset create radiant_development
+        rvm gemset use radiant_development
+fi
+
 cd ~/radiant
-bundle exec rake spec:extensions EXT=sheets
+
+# ensure fresh sheets code
+rm -rf vendor/extensions/sheets
+cp -r $start_path vendor/extensions/sheets
+bundle update radiant-sheets-extension
+
+RAILS_ENV=test bundle exec rake spec:extensions EXT=sheets --trace

--- a/spec/lib/javascript_tags_spec.rb
+++ b/spec/lib/javascript_tags_spec.rb
@@ -16,6 +16,10 @@ describe "Javascript Tags" do
     it { should render(%{<r:javascript slug="bogus" />}).with_error("javascript bogus not found") }
     it { should render(%{<r:javascript slug="site.js" />}).as('alert("site!");') }
     it { should render(%{<r:javascript slug="site.js" as="url" />}).as("/js/site.js?#{javascript_page.digest}") }
+    it { 
+      Radiant::Config['sheets.asset_host'] = "http://asset-host.com"
+      should render(%{<r:javascript slug="site.js" as="url" />}).as("http://asset-host.com/js/site.js?#{javascript_page.digest}") 
+    }
     it { should render(%{<r:javascript slug="site.js" as="link" />}).as(%{<script type="#{javascript_page.headers['Content-Type']}" src="#{javascript_page.path}"></script>}) }
     it { 
       Radiant::Config['sheets.asset_host'] = "http://asset-host.com"

--- a/spec/lib/javascript_tags_spec.rb
+++ b/spec/lib/javascript_tags_spec.rb
@@ -17,6 +17,10 @@ describe "Javascript Tags" do
     it { should render(%{<r:javascript slug="site.js" />}).as('alert("site!");') }
     it { should render(%{<r:javascript slug="site.js" as="url" />}).as("/js/site.js?#{javascript_page.digest}") }
     it { should render(%{<r:javascript slug="site.js" as="link" />}).as(%{<script type="#{javascript_page.headers['Content-Type']}" src="#{javascript_page.path}"></script>}) }
+    it { 
+      Radiant::Config['sheets.asset_host'] = "http://asset-host.com"
+      should render(%{<r:javascript slug="site.js" as="link" />}).as(%{<script type="#{javascript_page.headers['Content-Type']}" src="http://asset-host.com#{javascript_page.path}"></script>}) 
+    }
     it { should render(%{<r:javascript slug="site.js" as="link" type="special/type" />}).as(%{<script type="special/type" src="#{javascript_page.path}"></script>}) }
     it { should render(%{<r:javascript slug="site.js" as="link" something="custom" />}).as(%{<script type="#{javascript_page.headers['Content-Type']}" src="#{javascript_page.path}" something="custom"></script>}) }
     it { should render(%{<r:javascript slug="site.js" as="inline" />}).as(%{<script type="#{javascript_page.headers['Content-Type']}">

--- a/spec/lib/stylesheet_tags_spec.rb
+++ b/spec/lib/stylesheet_tags_spec.rb
@@ -16,6 +16,10 @@ describe "Stylesheet Tags" do
     it { should render(%{<r:stylesheet slug="bogus" />}).with_error("stylesheet bogus not found") }
     it { should render(%{<r:stylesheet slug="site.css" />}).as("p { color: blue; }") }
     it { should render(%{<r:stylesheet slug="site.css" as="url" />}).as("/css/site.css?#{site_css.digest}") }
+    it { 
+      Radiant::Config['sheets.asset_host'] = "http://asset-host.com"
+      should render(%{<r:stylesheet slug="site.css" as="url" />}).as("http://asset-host.com/css/site.css?#{site_css.digest}") 
+    }
     it { should render(%{<r:stylesheet slug="site.css" as="link" />}).as(%{<link rel="stylesheet" type="text/css" href="/css/site.css?#{site_css.digest}" />}) }
     it { 
       Radiant::Config['sheets.asset_host'] = "http://asset-host.com"

--- a/spec/lib/stylesheet_tags_spec.rb
+++ b/spec/lib/stylesheet_tags_spec.rb
@@ -17,6 +17,10 @@ describe "Stylesheet Tags" do
     it { should render(%{<r:stylesheet slug="site.css" />}).as("p { color: blue; }") }
     it { should render(%{<r:stylesheet slug="site.css" as="url" />}).as("/css/site.css?#{site_css.digest}") }
     it { should render(%{<r:stylesheet slug="site.css" as="link" />}).as(%{<link rel="stylesheet" type="text/css" href="/css/site.css?#{site_css.digest}" />}) }
+    it { 
+      Radiant::Config['sheets.asset_host'] = "http://asset-host.com"
+      should render(%{<r:stylesheet slug="site.css" as="link" />}).as(%{<link rel="stylesheet" type="text/css" href="http://asset-host.com/css/site.css?#{site_css.digest}" />}) 
+    }
     it { should render(%{<r:stylesheet slug="site.css" as="link" type="special/type" />}).as(%{<link rel="stylesheet" type="special/type" href="/css/site.css?#{site_css.digest}" />}) }
     it { should render(%{<r:stylesheet slug="site.css" as="link" something="custom" />}).as(%{<link rel="stylesheet" type="text/css" href="/css/site.css?#{site_css.digest}" something="custom" />}) }
     it { should render(%{<r:stylesheet slug="site.css" as="link" rel="alternate" />}).as(%{<link rel="alternate" type="text/css" href="/css/site.css?#{site_css.digest}" />}) }


### PR DESCRIPTION
Hello,

I've added support for `Radiant::Config['sheets.asset_host']` when using `as="url"`, `as="path"` and `as="link"` for both stylesheets and javascript. 

The purpose behind this specifically is for when loading assets off of a CDN or when using and Nginx proxy with a url rewrite to display radiant content (or in my case, both).

I've added tests to `spec/lib/*.rb` all of which are passing.

As an aside, I also made some to `spec/ci/*` to be a little more friendly to different environments, please feel free to disregard if you so choose.

Thanks,
J
